### PR TITLE
Chore: Minor fixes in Consul, Nomad and HVS tutorials

### DIFF
--- a/10-boundary/README.md
+++ b/10-boundary/README.md
@@ -1,5 +1,5 @@
 
-# Part 3: Boundary Integration
+# Part 10: Boundary Integration
 
 ## Background
 Our Hello app is already running with Consul, Nomad and Vault.

--- a/10-boundary/main.tf
+++ b/10-boundary/main.tf
@@ -230,7 +230,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "minion-key" {
-  key_name   = "minion-key"
+  key_name   = "minion-key-boundary"
   public_key = tls_private_key.pk.public_key_openssh
 }
 

--- a/2-terraform/main.tf
+++ b/2-terraform/main.tf
@@ -122,7 +122,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "minion-key" {
-  key_name   = "minion-key"
+  key_name   = "minion-key-terraform"
   public_key = tls_private_key.pk.public_key_openssh
 }
 

--- a/3-consul/main.tf
+++ b/3-consul/main.tf
@@ -237,7 +237,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "minion-key" {
-  key_name   = "minion-key"
+  key_name   = "minion-key-consul"
   public_key = tls_private_key.pk.public_key_openssh
 }
 

--- a/3-consul/shared/data-scripts/user-data-client.sh
+++ b/3-consul/shared/data-scripts/user-data-client.sh
@@ -21,7 +21,7 @@ if [ "${application_name}" = "hello-service" ]; then
   sudo docker run -d --name ${application_name} --network=host ${dockerhub_id}/helloservice:latest
 elif [ "${application_name}" = "response-service" ]; then
   sudo docker image pull ${dockerhub_id}/responseservice:latest
-  sudo docker run -d --name ${application_name} --network=host ${dockerhub_id}/responseservice:latest
+  sudo docker run -d --name ${application_name} -e TF_VAR_dockerhub_id=${dockerhub_id} --network=host ${dockerhub_id}/responseservice:latest
 else
   echo "Unknown application name: ${application_name}"
 fi

--- a/4-nomad/README.md
+++ b/4-nomad/README.md
@@ -1,5 +1,5 @@
 
-# Part 3: Nomad Integration
+# Part 4: Nomad Integration
 
 ## Background
 Our Hello app is already running with following limitations

--- a/4-nomad/ResponseService/main.go
+++ b/4-nomad/ResponseService/main.go
@@ -33,7 +33,7 @@ func responseHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 
 	// register your progress in leadership board
-	err = registerProgress("consul")
+	err = registerProgress("nomad")
 	if err != nil {
 		// set http status code to 500
 		http.Error(w, fmt.Sprintf("Failed to register progress %v", err), http.StatusInternalServerError)

--- a/4-nomad/main.tf
+++ b/4-nomad/main.tf
@@ -234,7 +234,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "minion-key" {
-  key_name   = "minion-key"
+  key_name   = "minion-key-nomad"
   public_key = tls_private_key.pk.public_key_openssh
 }
 

--- a/6-leaderboard/terraform/main.tf
+++ b/6-leaderboard/terraform/main.tf
@@ -172,7 +172,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "leaderboard-key" {
-  key_name   = "leaderboard-key"
+  key_name   = "minion-key-leaderboard"
   public_key = tls_private_key.pk.public_key_openssh
 }
 

--- a/7-hvs/image.pkr.hcl
+++ b/7-hvs/image.pkr.hcl
@@ -77,7 +77,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["CLOUD_ENV=aws", "DOCKERHUB_ID=${var.dockerhub_id}"],
+    environment_vars = ["CLOUD_ENV=aws", "DOCKERHUB_ID=${var.dockerhub_id}"]
     script           = "./shared/scripts/setup.sh"
   }
 }

--- a/8-observability/README.md
+++ b/8-observability/README.md
@@ -83,7 +83,7 @@ Prometheus scrapes metrics from the following targets:
 - **response-service**: `response-service.service.consul:6060`
 
 The Prometheus config is defined in `prometheus.yml`. To view the metrics:
-- Open **Prometheus** at: `http://<nomad-server-ip>:9090`.
+- Open **Prometheus** at: `http://<nomad-client-ip>:9090`.
 - Explore the available targets under **Status > Targets**.
 
 ---
@@ -92,7 +92,7 @@ The Prometheus config is defined in `prometheus.yml`. To view the metrics:
 
 Let’s make those metrics beautiful! 🎨
 
-1. Open **Grafana** at: `http://<nomad-server-ip>:3000`.
+1. Open **Grafana** at: `http://<nomad-client-ip>:3000`.
 2. Import pre-built dashboards:
     - Go to **Dashboards > Import**.
     - Upload the JSON files from the `grafana-dashboards` folder.
@@ -106,7 +106,7 @@ Now let’s configure alerting rules to notify us when something goes wrong.
 
 Alertmanager is already provisioned to handle alerts from Prometheus and send them to a webhook.
 
-You can access **Alertmanager UI** at: `http://<nomad-server-ip>:9093`
+You can access **Alertmanager UI** at: `http://<nomad-client-ip>:9093`
 
 Here’s an example alert rule:
 - **Alert**: `InstanceDown`

--- a/8-observability/main.tf
+++ b/8-observability/main.tf
@@ -286,7 +286,7 @@ resource "tls_private_key" "pk" {
 }
 
 resource "aws_key_pair" "minion-key" {
-  key_name   = "minion-key"
+  key_name   = "minion-key-observability"
   public_key = tls_private_key.pk.public_key_openssh
 }
 


### PR DESCRIPTION
### Summary
- Consul: Set `TF_VAR_dockerhub_id` for the response service container so progress can be logged
- Nomad: Register progress for Nomad instead of Consul
- HVS: Remove additional comma in Packer configuration file
- Use unique names for EC2 key pairs to avoid collision
- Update observability README
