### PR TITLE
fix(consul): Response service health check failures

### DIFF
--- a/3-consul/ResponseService/main.go
+++ b/3-consul/ResponseService/main.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
-	"strings"
 )
 
 // responseHandler handles the response to the client
@@ -35,13 +33,6 @@ func responseHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 
-	// register your progress in leadership board
-	err = registerProgress("consul")
-	if err != nil {
-		// set http status code to 500
-		http.Error(w, fmt.Sprintf("Failed to register progress %v", err), http.StatusInternalServerError)
-		return
-	}
 }
 
 // Reading from Consul KV store
@@ -146,46 +137,6 @@ func registerService(service string, port int, healthEp string) {
 	}
 	defer resp.Body.Close()
 	fmt.Println("Service registered successfully with Consul.")
-}
-
-// Register progress in leadership board
-func registerProgress(game string) error {
-	// register progress in leadership board
-	url := "http://leaderboard.ashesh-vidyut.sbx.hashidemos.io/api/"
-	// make a post call with header
-	req, err := http.NewRequest("POST", url, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	// UGLY WAY OF HANDLING SECRET, for demo purpose only
-	req.Header.Set("token", "ECD9823E-6E7E-42F0-BD72-1CA381098C0D")
-
-	// get dockerhub_id from environment variable
-	dockerhub_id := os.Getenv("TF_VAR_dockerhub_id")
-	if dockerhub_id == "" {
-		// error handling
-		return fmt.Errorf("TF_VAR_dockerhub_id not set")
-	}
-
-	payload := fmt.Sprintf(`{"user": "%s", "game": "%s"}`, dockerhub_id, game)
-	req.Body = io.NopCloser(strings.NewReader(payload))
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("Failed to register progress %v", err)
-	}
-	defer resp.Body.Close()
-
-	// read response body
-	msg, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("Failed to read response body %v", err)
-	}
-	fmt.Println(string(msg))
-
-	return nil
 }
 
 func main() {


### PR DESCRIPTION
Health check for the response service required a response from [this hardcoded url](https://github.com/3loka/minion-chat/blob/4084cfbdec1c0c44db2072fcc1a3fd6526a0c5c8/3-consul/ResponseService/main.go#L154) which did not exist hence consul was not reporting these services as healthy.
Progress reporting made optional by introduction of an environment variable `PROGRESS_API_URL`, whose absence will skip reporting the progress to the leaderboard.